### PR TITLE
Adds a new edge tracing parameter

### DIFF
--- a/pypeit/core/trace.py
+++ b/pypeit/core/trace.py
@@ -1225,8 +1225,8 @@ def build_trace_bpm(flux, trace_cen, bpm=None, boxcar=None, thresh=None, median_
 # so it takes only the highest peaks from detect_lines
 def peak_trace(flux, ivar=None, bpm=None, trace_map=None, extract_width=None, smash_range=None,
                peak_thresh=100.0, peak_clip=None, trough=False, trace_median_frac=0.01,
-               trace_thresh=10.0, fwhm_uniform=3.0, fwhm_gaussian=3.0, maxshift=None,
-               maxerror=None, function='legendre', order=5, maxdev=5.0, maxiter=25,
+               trace_thresh=10.0, fwhm_uniform=3.0, fwhm_gaussian=3.0, min_pkdist_frac_fwhm=5.0,
+               maxshift=None, maxerror=None, function='legendre', order=5, maxdev=5.0, maxiter=25,
                niter_uniform=9, niter_gaussian=6, bitmask=None, show_fits=False, show_peaks=False):
     """
     Find and trace features in an image by identifying peaks/troughs
@@ -1334,6 +1334,10 @@ def peak_trace(flux, ivar=None, bpm=None, trace_map=None, extract_width=None, sm
             The ``fwhm`` parameter to use when using Gaussian
             weighting in the calls to :func:`fit_trace`. See
             description of the algorithm above.
+        min_pkdist_frac_fwhm (:obj:`float`, optional):
+            Minimum allowed separation between same-side edge detections
+            expressed relative to fwhm_gaussian.  See
+            :func:`~pypeit.core.arc.detect_lines`.
         maxshift (:obj:`float`, optional):
             Maximum shift allowed between the input and recalculated
             centroid (see :func:`fit_trace`).
@@ -1459,7 +1463,7 @@ def peak_trace(flux, ivar=None, bpm=None, trace_map=None, extract_width=None, sm
         peak, _, _cen, _, _, best, _, _ \
                 = arc.detect_lines(s*flux_smash_mean, cont_subtract=False, fwhm=fwhm_gaussian,
                                    input_thresh=peak_thresh, max_frac_fwhm=4.0,
-                                   min_pkdist_frac_fwhm=5.0, debug=show_peaks)
+                                   min_pkdist_frac_fwhm=min_pkdist_frac_fwhm, debug=show_peaks)
 
         if len(_cen) == 0 or not np.any(best):
             msgs.warn('No good {0}s found!'.format(l))

--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -2740,11 +2740,7 @@ class EdgeTraceSet(calibframe.CalibFrame):
             self.edge_fit = self.edge_fit[:,keep]
         self.traceid = self.traceid[keep]
         if self.maskdef_id is not None:
-            try:
-                self.maskdef_id = self.maskdef_id[keep]
-            except:
-                embed()
-                exit()
+            self.maskdef_id = self.maskdef_id[keep]
 
         if resort:
             # Resort by the spatial dimension
@@ -3485,6 +3481,7 @@ class EdgeTraceSet(calibframe.CalibFrame):
         niter_uniform = self.par['niter_uniform']
         fwhm_gaussian = self.par['fwhm_gaussian']
         niter_gaussian = self.par['niter_gaussian']
+        min_edge_side_sep = self.par['min_edge_side_sep']
         maxdev = self.par['fit_maxdev']
         maxiter = self.par['fit_maxiter']
 
@@ -3501,6 +3498,8 @@ class EdgeTraceSet(calibframe.CalibFrame):
         msgs.info('Number of uniform-weighted iterations: {0:.1f}'.format(niter_uniform))
         msgs.info('FWHM parameter for Gaussian-weighted centroids: {0:.1f}'.format(fwhm_gaussian))
         msgs.info('Number of Gaussian-weighted iterations: {0:.1f}'.format(niter_gaussian))
+        msgs.info('Minimum separation between any two subsequent edges of the same side: '
+                  f'{fwhm_gaussian * min_edge_side_sep:.1f} pixels')
         msgs.info('Maximum deviation for fitted data: {0:.1f}'.format(maxdev))
         msgs.info('Maximum number of rejection iterations: {0}'.format(maxiter))
 
@@ -3532,9 +3531,10 @@ class EdgeTraceSet(calibframe.CalibFrame):
                                            smash_range=smash_range, peak_thresh=peak_thresh,
                                            peak_clip=peak_clip, trace_median_frac=trace_median_frac,
                                            trace_thresh=trace_thresh, fwhm_uniform=fwhm_uniform,
-                                           fwhm_gaussian=fwhm_gaussian, function=function,
-                                           order=order, maxdev=maxdev, maxiter=maxiter,
-                                           niter_uniform=niter_uniform,
+                                           fwhm_gaussian=fwhm_gaussian, 
+                                           min_pkdist_frac_fwhm=min_edge_side_sep,
+                                           function=function, order=order, maxdev=maxdev,
+                                           maxiter=maxiter, niter_uniform=niter_uniform,
                                            niter_gaussian=niter_gaussian, bitmask=self.bitmask,
                                            show_fits=show_fits, show_peaks=show_peaks)
                 fit = np.hstack((fit,_fit))
@@ -3558,10 +3558,12 @@ class EdgeTraceSet(calibframe.CalibFrame):
                                        peak_clip=peak_clip, trough=True,
                                        trace_median_frac=trace_median_frac,
                                        trace_thresh=trace_thresh, fwhm_uniform=fwhm_uniform,
-                                       fwhm_gaussian=fwhm_gaussian, function=function, order=order,
-                                       maxdev=maxdev, maxiter=maxiter, niter_uniform=niter_uniform,
-                                       niter_gaussian=niter_gaussian, bitmask=self.bitmask,
-                                       show_fits=show_fits, show_peaks=show_peaks)
+                                       fwhm_gaussian=fwhm_gaussian, 
+                                       min_pkdist_frac_fwhm=min_edge_side_sep, function=function,
+                                       order=order, maxdev=maxdev, maxiter=maxiter,
+                                       niter_uniform=niter_uniform, niter_gaussian=niter_gaussian,
+                                       bitmask=self.bitmask, show_fits=show_fits,
+                                       show_peaks=show_peaks)
 
         # Assess the output
         ntrace = fit.shape[1]

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -3286,13 +3286,14 @@ class EdgeTracePar(ParSet):
                  pca_order=None, pca_sigrej=None, pca_maxrej=None, pca_maxiter=None,
                  smash_range=None, edge_detect_clip=None, trace_median_frac=None, trace_thresh=None,
                  trace_rms_tol=None, fwhm_uniform=None, niter_uniform=None, fwhm_gaussian=None,
-                 niter_gaussian=None, det_buffer=None, max_nudge=None, sync_predict=None,
-                 sync_center=None, gap_offset=None, sync_to_edge=None, bound_detector=None,
-                 minimum_slit_dlength=None, dlength_range=None, minimum_slit_length=None,
-                 minimum_slit_length_sci=None, length_range=None, minimum_slit_gap=None, clip=None,
-                 order_match=None, order_offset=None, add_missed_orders=None, order_width_poly=None,
-                 order_gap_poly=None, order_fitrej=None, order_outlier=None, order_spat_range=None,
-                 overlap=None, max_overlap=None, use_maskdesign=None, maskdesign_maxsep=None,
+                 niter_gaussian=None, min_edge_side_sep=None, det_buffer=None, max_nudge=None,
+                 sync_predict=None, sync_center=None, gap_offset=None, sync_to_edge=None,
+                 bound_detector=None, minimum_slit_dlength=None, dlength_range=None,
+                 minimum_slit_length=None, minimum_slit_length_sci=None, length_range=None,
+                 minimum_slit_gap=None, clip=None, order_match=None, order_offset=None,
+                 add_missed_orders=None, order_width_poly=None, order_gap_poly=None,
+                 order_fitrej=None, order_outlier=None, order_spat_range=None, overlap=None,
+                 max_overlap=None, use_maskdesign=None, maskdesign_maxsep=None,
                  maskdesign_step=None, maskdesign_sigrej=None, pad=None, add_slits=None,
                  add_predict=None, rm_slits=None, maskdesign_filename=None, mask_off_detector=None):
 
@@ -3528,7 +3529,7 @@ class EdgeTracePar(ParSet):
         dtypes['fwhm_gaussian'] = [int, float]
         descr['fwhm_gaussian'] = 'The `fwhm` parameter to use when using Gaussian weighting in ' \
                                  ':func:`~pypeit.core.trace.fit_trace` when refining the PCA ' \
-                                 'predictions of edges.  See description ' \
+                                 'predictions of edges.  See description of ' \
                                  ':func:`~pypeit.core.trace.peak_trace`.'
 
         defaults['niter_gaussian'] = 6
@@ -3536,6 +3537,15 @@ class EdgeTracePar(ParSet):
         descr['niter_gaussian'] = 'The number of iterations of ' \
                                   ':func:`~pypeit.core.trace.fit_trace` to use when using ' \
                                   'Gaussian weighting.'
+        
+        defaults['min_edge_side_sep'] = 5.0
+        dtypes['min_edge_side_sep'] = [int, float]
+        descr['min_edge_side_sep'] = 'Minimum separation between same-side edges (e.g., the ' \
+                                     'minimum separation between two subsequent right-edge ' \
+                                     'detections) in units of ``fwhm_gaussian``.  For example, ' \
+                                     'if ``fwhm_gaussian = 3.0`` and ``min_edge_sid_sep = 5.``, ' \
+                                     'the separation between subsequent right edges must be at ' \
+                                     'least 15 pixels.'
 
         defaults['det_buffer'] = 5
         dtypes['det_buffer'] = int
@@ -3880,15 +3890,16 @@ class EdgeTracePar(ParSet):
                    'left_right_pca', 'pca_min_edges', 'pca_n', 'pca_var_percent', 'pca_function',
                    'pca_order', 'pca_sigrej', 'pca_maxrej', 'pca_maxiter', 'smash_range',
                    'edge_detect_clip', 'trace_median_frac', 'trace_thresh', 'trace_rms_tol',
-                   'fwhm_uniform', 'niter_uniform', 'fwhm_gaussian', 'niter_gaussian', 'det_buffer',
-                   'max_nudge', 'sync_predict', 'sync_center', 'gap_offset', 'sync_to_edge',
-                   'bound_detector', 'minimum_slit_dlength', 'dlength_range', 'minimum_slit_length',
-                   'minimum_slit_length_sci', 'length_range', 'minimum_slit_gap', 'clip',
-                   'order_match', 'order_offset',  'add_missed_orders', 'order_width_poly',
-                   'order_gap_poly', 'order_fitrej', 'order_outlier', 'order_spat_range','overlap',
-                   'max_overlap', 'use_maskdesign', 'maskdesign_maxsep', 'maskdesign_step',
-                   'maskdesign_sigrej', 'maskdesign_filename', 'pad', 'add_slits', 'add_predict',
-                   'rm_slits', 'mask_off_detector']
+                   'fwhm_uniform', 'niter_uniform', 'fwhm_gaussian', 'niter_gaussian',
+                   'min_edge_side_sep', 'det_buffer', 'max_nudge', 'sync_predict', 'sync_center',
+                   'gap_offset', 'sync_to_edge', 'bound_detector', 'minimum_slit_dlength',
+                   'dlength_range', 'minimum_slit_length', 'minimum_slit_length_sci',
+                   'length_range', 'minimum_slit_gap', 'clip', 'order_match', 'order_offset',
+                   'add_missed_orders', 'order_width_poly', 'order_gap_poly', 'order_fitrej',
+                   'order_outlier', 'order_spat_range','overlap', 'max_overlap', 'use_maskdesign',
+                   'maskdesign_maxsep', 'maskdesign_step', 'maskdesign_sigrej',
+                   'maskdesign_filename', 'pad', 'add_slits', 'add_predict', 'rm_slits',
+                   'mask_off_detector']
 
         # Find the list of keywords provded in `cfg` that are *not* valid
         badkeys = np.array([pk not in parkeys for pk in k])

--- a/pypeit/spectrographs/p200_ngps.py
+++ b/pypeit/spectrographs/p200_ngps.py
@@ -279,11 +279,10 @@ class P200NGPSSpectrograph_r(P200NGPSSpectrograph):
         par = super().default_pypeit_par()
 
         par['calibrations']['slitedges']['sync_predict'] = 'nearest'
-        par['calibrations']['slitedges']['edge_thresh'] = 10. # Lower edge tracing thresdhold to catch leftmost slit
-
+        par['calibrations']['slitedges']['edge_thresh'] = 50. # Lower edge tracing thresdhold to catch leftmost slit
         par['calibrations']['slitedges']['minimum_slit_length'] = 100 # Set minimum slit length 
-
-        par['calibrations']['slitedges']['add_slits'] = ['1:2090:24:153']
+        par['calibrations']['slitedges']['min_edge_side_sep'] = 1.0
+#        par['calibrations']['slitedges']['add_slits'] = ['1:2090:24:153']
         
         par['scienceframe']['process']['combine'] = 'median'
         par['calibrations']['standardframe']['process']['combine'] = 'median'
@@ -445,11 +444,10 @@ class P200NGPSSpectrograph_i(P200NGPSSpectrograph):
         par = super().default_pypeit_par()
 
         par['calibrations']['slitedges']['sync_predict'] = 'nearest'
-        par['calibrations']['slitedges']['edge_thresh'] = 10. # Lower edge tracing thresdhold to catch leftmost slit
-       
+        par['calibrations']['slitedges']['edge_thresh'] = 50. # Lower edge tracing thresdhold to catch leftmost slit
         par['calibrations']['slitedges']['minimum_slit_length'] = 100 # Set minimum slit length 
-
-        par['calibrations']['slitedges']['add_slits'] = ['1:2035:123:251']
+        par['calibrations']['slitedges']['min_edge_side_sep'] = 1.0
+#        par['calibrations']['slitedges']['add_slits'] = ['1:2035:123:251']
         
         par['scienceframe']['process']['combine'] = 'median'
         par['calibrations']['standardframe']['process']['combine'] = 'median'


### PR DESCRIPTION
The issue with the edge tracing always ignoring the left-most slit was due to one of the very narrow traces in the image.  The code had a hard-coded minimum separation between two edge detections for the same side of a slit.  By default, this was 15 pixels, and the code was finding two right edges only separated by 6 pixels.  It was keeping the one associated with the very narrow trace and removing the one that should have been kept.  This PR makes the previously hard-coded number a parameter (`min_edge_side_sep`) that can be changed, and sets the default to 1.0 for P200/NGPS.  The global default is 5.0.

This fixes the edge detection at least for the `p200_ngps_r/1.0_2x2` dataset.  If the narrow trace is always present, this should be fine.  But if it is variable, we should add some recommendations in a doc specific to P200/NGPS that users may need to set `min_edge_side_sep` for each dataset.